### PR TITLE
Add brackets to extended string completions

### DIFF
--- a/bin/jq-paths
+++ b/bin/jq-paths
@@ -3,10 +3,14 @@
 JQ_REPL_JQ="${JQ_REPL_JQ:-jq}"
 $JQ_REPL_JQ -r '
 [
-  path(..) | map(
-    if type == "string" and test("[^A-z0-9_]") then
-        gsub("^(?<match>.*)$";"[\"\(.match)\"]") 
-    else "[]" end)
-  | join(".")
-] | sort | unique | .[] | split(".[]") | join("[]") | "." + .
+  path(..)  |
+  map(
+    # use generic object index syntax if key contains non-alphanumeric characters or starts with a digit
+    select(type == "string" and (test("[^a-zA-Z0-9_]") or test("^[0-9]"))) |= "[\"" + . + "\"]"
+  ) |
+  map(
+    # numbers are assumed to be array indexes only
+    select(type == "number") |= "[]"
+  ) | join(".")
+] | sort | unique | .[] | split(".[") | join("[") | "." + .
 '

--- a/bin/jq-paths
+++ b/bin/jq-paths
@@ -3,7 +3,10 @@
 JQ_REPL_JQ="${JQ_REPL_JQ:-jq}"
 $JQ_REPL_JQ -r '
 [
-  path(..) | map(select(type == "string") // "[]")
+  path(..) | map(
+    if type == "string" and test("[^A-z0-9_]") then
+        gsub("^(?<match>.*)$";"[\"\(.match)\"]") 
+    else "[]" end)
   | join(".")
 ] | sort | unique | .[] | split(".[]") | join("[]") | "." + .
 '


### PR DESCRIPTION
Per the [jq manual](https://stedolan.github.io/jq/manual/#Basicfilters), the basic object identifier syntax (`.foo`) only works on simple strings containing only alphanumeric characters and underscores. This patch extends the path completion for strings which contain non-alphanumeric characters, such as hyphens. The spec also states that simple keys cannot start with a digit, so the test regex could arguably be updated to something like `test("^[A-z_][A-z0-9_]+$") | not`.