### PR TITLE
Add pre-filter

### DIFF
--- a/bin/jq-paths
+++ b/bin/jq-paths
@@ -1,16 +1,22 @@
 #!/bin/sh
 # path logic inspired by https://github.com/stedolan/jq/issues/243
 JQ_REPL_JQ="${JQ_REPL_JQ:-jq}"
-$JQ_REPL_JQ -r '
-[
-  path(..)  |
-  map(
-    # use generic object index syntax if key contains non-alphanumeric characters or starts with a digit
-    select(type == "string" and (test("[^a-zA-Z0-9_]") or test("^[0-9]"))) |= "[\"" + . + "\"]"
-  ) |
-  map(
-    # numbers are assumed to be array indexes only
-    select(type == "number") |= "[]"
-  ) | join(".")
-] | sort | unique | .[] | split(".[") | join("[") | "." + .
-'
+FILTER='.'
+if [[ $# -ne 0 ]]; then
+  FILTER="${1}"
+fi
+
+${JQ_REPL_JQ} "${FILTER}" | ${JQ_REPL_JQ} --raw-output '
+  [
+    path(..)  |
+    map(
+      # use generic object index syntax if key contains non-alphanumeric characters or starts with a digit
+      select(type == "string" and (test("[^a-zA-Z0-9_]") or test("^[0-9]"))) |= "[\"" + . + "\"]"
+    ) |
+    map(
+      # numbers are assumed to be array indexes only
+      select(type == "number") |= "[]"
+    ) | join(".")
+  ] | sort | unique | .[] | split(".[") | join("[") | "." + .
+  ' | sort -u |
+  awk -v prefix="${FILTER}" 'BEGIN { if (prefix==".") { prefix="" } else { prefix=prefix "| " } }$0=prefix$0'

--- a/bin/jq-repl
+++ b/bin/jq-repl
@@ -40,4 +40,4 @@ eval "$FZF_JQ_REPL_COMMAND" |
     --query="." \
     --bind "tab:replace-query,return:print-query" \
     --bind "alt-up:preview-page-up,alt-down:preview-page-down" \
-    --bind "ctrl-r:reload${fzf_notation}${FZF_JQ_REPL_COMMAND}${fzf_notation}+refresh-preview"
+    --bind "ctrl-r:reload${fzf_notation}${FZF_JQ_REPL_COMMAND} {q}${fzf_notation}+refresh-preview"


### PR DESCRIPTION
The additional `sort -u` is needed in the case that the pre-filter results in JSON that is not an array. The remaining `awk` logic is to handle the base `.` case so that it doesn't result in `..` at the beginning. Alternatively, `FILTER=''` could be the default, as `jq` handles empty invocation as equivalent to `jq '.'`. I haven't tested this behavior with `gojq`, `jaq`, or any others, so I continued with your original suggestion.