### PR TITLE
Fix SC2155

### DIFF
--- a/jq.plugin.zsh
+++ b/jq.plugin.zsh
@@ -14,7 +14,8 @@ __get_query() {
 }
 
 jq-complete() {
-    local query="$(__get_query)"
+    local query
+    query="$(__get_query)"
     local ret=$?
     if [ -n "$query" ]; then
         LBUFFER="${LBUFFER} | ${JQ_REPL_JQ:-jq}"


### PR DESCRIPTION
```
In jq.plugin.zsh line 17:
    local query="$(__get_query)"
          ^---^ SC2155 (warning): Declare and assign separately to avoid masking return values.
```
https://www.shellcheck.net/wiki/SC2155