### PR TITLE
Add JQ_PATHS_ARGS to jq-paths

### DIFF
--- a/bin/jq-paths
+++ b/bin/jq-paths
@@ -1,7 +1,10 @@
 #!/bin/sh
 # path logic inspired by https://github.com/stedolan/jq/issues/243
 JQ_REPL_JQ="${JQ_REPL_JQ:-jq}"
-$JQ_REPL_JQ -r '
+# JQ_PATHS_ARGS has to be unquoted so it's passed as cli args to jq so
+# word splitting is desirable here
+# shellcheck disable=SC2086
+$JQ_REPL_JQ ${JQ_PATHS_ARGS:-} -r '
 [
   path(..)  |
   map(


### PR DESCRIPTION
### What?
This is a reopen from #24. It adds a new variable `$JQ_PATHS_ARGS` to the call in `jq-paths` to be in line with the usage in `jq-repl` and `jq-complete`.

### Why?
This plugin can simultaneously support JSON _and YAML_ with the help of `gojq` by simply setting:
```bash
export JQ_REPL_JQ=gojq
export JQ_REPL_ARGS=--yaml-input
export JQ_PATHS_ARGS=--yaml-input
```
However, actual yaml input will currently result in errors, which are likely caused by the `jq-paths` command not using the `--yaml-input` arg.