### PR TITLE
Use `env` to find `bash`

### DIFF
--- a/bin/jq-repl-preview
+++ b/bin/jq-repl-preview
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 JQ_REPL_JQ="${JQ_REPL_JQ:-jq}"
 


### PR DESCRIPTION
Hey there -- great plugin! I've been using this puppy for a few years and find it super simple and useful. Thanks for your work on this project!

---

On some systems like NixOS, bash is not found at `/bin/bash`. This causes the following error when starting the plugin:

```
bad interpreter: /bin/bash: no such file or directory
```

This commit uses `/usr/bin/env` to find `bash`, improving portability across environments.