### PR TITLE
jq-repl: support more (and custom) clipboard copy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ JQ_REPL_JQ=gojq
 
 ## Alternative clipboard copy command support
 
-By default, the <key>Ctrl-Y</key> hotkey uses `xclip` to copy the jq expression
-to the X11 clipboard, if installed and `$DISPLAY` environment variable is set.
+By default, the <key>Ctrl-Y</key> hotkey uses `wl-copy` or `xclip` to copy the
+jq expression to the Wayland or X11 clipboard, if the respective program is
+installed and `$WAYLAND_DISPLAY` or `$DISPLAY` environment variable is set.
 
 Alternatively, it is possible to provide a custom clipboard copy command by
 setting an environment variable:
 
 ```sh
-JQ_REPL_COPY="wl-copy -t text/plain"
 JQ_REPL_COPY="tmux load-buffer -"
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ JQ_REPL_JQ=gojq
 ## Alternative clipboard copy command support
 
 By default, the <key>Ctrl-Y</key> hotkey uses `xclip` to copy the jq expression
-to the X11 clipboard, if installed.
+to the X11 clipboard, if installed and `$DISPLAY` environment variable is set.
 
 Alternatively, it is possible to provide a custom clipboard copy command by
 setting an environment variable:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ can override the default jq command used by the plugin. Set the following enviro
 JQ_REPL_JQ=gojq
 ```
 
+## Alternative clipboard copy command support
+
+By default, the <key>Ctrl-Y</key> hotkey uses `xclip` to copy the jq expression
+to the X11 clipboard, if installed.
+
+Alternatively, it is possible to provide a custom clipboard copy command by
+setting an environment variable:
+
+```sh
+JQ_REPL_COPY="wl-copy -t text/plain"
+JQ_REPL_COPY="tmux load-buffer -"
+```
+
+This command must accept the copied text on stdin.
+
 ## Internals
 
 The project consists of the following components:

--- a/bin/jq-repl
+++ b/bin/jq-repl
@@ -37,7 +37,7 @@ fi
 
 if [ -n "$JQ_REPL_COPY" ]; then
   :
-elif command -v xclip >/dev/null; then
+elif command -v xclip >/dev/null && [ -n "$DISPLAY" ]; then
   JQ_REPL_COPY="xclip -in -sel clip"
 # other platforms can be supported here as needed
 fi

--- a/bin/jq-repl
+++ b/bin/jq-repl
@@ -37,6 +37,8 @@ fi
 
 if [ -n "$JQ_REPL_COPY" ]; then
   :
+elif command -v wl-copy >/dev/null && [ -n "$WAYLAND_DISPLAY" ]; then
+  JQ_REPL_COPY="wl-copy -t text/plain"
 elif command -v xclip >/dev/null && [ -n "$DISPLAY" ]; then
   JQ_REPL_COPY="xclip -in -sel clip"
 # other platforms can be supported here as needed

--- a/bin/jq-repl
+++ b/bin/jq-repl
@@ -35,12 +35,19 @@ if [ -z "$fzf_notation" ]; then
   fzf_notation="#"
 fi
 
-# default ignore
-FZF_COPY_TO_CLIPBOARD="execute-silent(ignore)"
-
+if [ -n "$JQ_REPL_COPY" ]; then
+  :
+elif command -v xclip >/dev/null; then
+  JQ_REPL_COPY="xclip -in -sel clip"
 # other platforms can be supported here as needed
-command -v xclip > /dev/null && \
-  FZF_COPY_TO_CLIPBOARD="execute-silent(echo -n {} | xclip -in -sel clip)+abort"
+fi
+
+if [ -n "$JQ_REPL_COPY" ]; then
+  FZF_COPY_TO_CLIPBOARD="execute-silent(echo -n {} | $JQ_REPL_COPY)+abort"
+else
+  # default ignore
+  FZF_COPY_TO_CLIPBOARD="ignore"
+fi
 
 eval "$FZF_JQ_REPL_COMMAND" |
   fzf \


### PR DESCRIPTION
This PR adds support for Wayland clipboard using `wl-copy` and arbitrary custom clipboard commands via `$JQ_REPL_COPY` environment variable.

Additionally, the default logic is refined such that a default command (`xclip` or `wl-copy`) is only used if the respective graphical session is present, as indicated by the `$DISPLAY` or `$WAYLAND_DISPLAY` environment variable being present.