### PR TITLE
jq.plugin: support custom jq-like tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jq zsh plugin
 
 Interactively build [jq](https://stedolan.github.io/jq/) expressions ([gojq](https://github.com/itchyny/gojq)
-is also supported).
+or any other jq-like program is also supported).
 
 This zsh plugin gives you jq superpowers!
 
@@ -106,14 +106,26 @@ During interactive querying, the following shortcuts can be used:
 | `ctrl-r`                 | Reload input                                     |
 | `ctrl-y`                 | Yank selected path to clipboard (GNU/Linux only) |
 
-## gojq support
+## Alternative tool support
 
-If you want to use an alternative `jq` implementation, like [gojq](https://github.com/itchyny/gojq) then you
-can override the default jq command used by the plugin. Set the following environment variable:
+If you want to use an alternative `jq` implementation, like [gojq](https://github.com/itchyny/gojq), then you
+can override the default jq command used by the plugin by setting an environment variable:
 
 ```sh
 JQ_REPL_JQ=gojq
 ```
+
+Additionally, multiple jq-like tools may be used at the same time with different
+keybindings. To bind a custom key sequence to an instance of the jq plugin using
+your specific command in lieu of `jq`, call the following function after loading
+the plugin:
+
+```sh
+_jq-add-complete '\ey' 'yq'
+```
+
+In this example, `\ey` is the code for <key>Alt-Y</key> sequence (also see below
+for possible gotchas), and `yq` is the custom command to run.
 
 ## Internals
 

--- a/jq.plugin.zsh
+++ b/jq.plugin.zsh
@@ -20,12 +20,13 @@ if [[ -o zle ]]; then
     fi
   }
 
-  jq-complete() {
+  __jq-complete() {
+    local jq="${1:-${JQ_REPL_JQ:-jq}}"
     local query
-    query="$(__get_query)"
+    query="$(JQ_REPL_JQ="$jq" __get_query)"
     local ret=$?
     if [ -n "$query" ]; then
-      LBUFFER="$(__lbuffer_strip_trailing_pipe) | ${JQ_REPL_JQ:-jq}"
+      LBUFFER="$(__lbuffer_strip_trailing_pipe) | $jq"
       [[ -z "$JQ_REPL_ARGS" ]] || LBUFFER="${LBUFFER} ${JQ_REPL_ARGS}"
       LBUFFER="${LBUFFER} '$query'"
     fi
@@ -33,9 +34,18 @@ if [[ -o zle ]]; then
     return $ret
   }
 
-  zle -N jq-complete
-  # bind `alt + j` to jq-complete
-  bindkey '\ej' jq-complete
+  _jq-add-complete() {
+    local key="$1" command="$2"
+
+    local funcname="jq-complete${command+"-${command%% }"}"
+    eval "$funcname() { __jq-complete ${command+"${(q)command}"}; }"
+
+    zle -N "$funcname"
+    bindkey "$key" "$funcname"
+  }
+
+  # bind `alt + j` to jq-complete using jq
+  _jq-add-complete '\ej'
 fi
 
 export PATH=$PATH:${0:A:h}/bin


### PR DESCRIPTION
This PR adds support for using multiple arbitrary jq-like tools simultaneously by binding them to different key sequences.

A helper function `_jq-add-complete` is introduced that may be invoked by the user to create a new ZLE widget that uses a specific jq-like command, and bind that widget to a key sequence.